### PR TITLE
chore(cursor): regras do Cursor e backup script com push automático

### DIFF
--- a/.cursor/rules/01-projeto.mdc
+++ b/.cursor/rules/01-projeto.mdc
@@ -1,0 +1,21 @@
+---
+alwaysApply: true
+---
+# Guia do Projeto (dotfiles)
+
+- Principal script de backup: [dotfiles_backup.sh](mdc:dotfiles_backup.sh)
+- SO alvo: macOS (zsh)
+- Destino fixo dos backups: `/Users/gabrielramos/dotfiles`
+- Nome do tarball: `dotfiles-${HOSTNAME}-${TIMESTAMP}.tar.gz`
+- Exportações adicionais:
+  - Brewfile via `brew bundle dump`
+  - Extensões do VS Code via `code --list-extensions`
+  - Manifestos: `manifest.sha256` e `inventory.txt`
+- Itens sensíveis são excluídos do backup (ex.: chaves privadas de SSH)
+
+Fluxo do script de backup:
+
+1. Copia itens de interesse com `rsync` e exclusões predefinidas
+2. Gera manifestos e metadados
+3. Empacota em tarball no diretório do projeto
+4. (Opcional) Faz commit e push do tarball para `origin` no branch atual

--- a/.cursor/rules/02-bash-style.mdc
+++ b/.cursor/rules/02-bash-style.mdc
@@ -1,0 +1,13 @@
+---
+globs: *.sh
+---
+# Estilo e Padrões para Scripts Bash
+
+- Sempre iniciar com `#!/usr/bin/env bash` e `set -euo pipefail`
+- Usar funções com nomes descritivos; preferir retornos antecipados (early return)
+- Declarar variáveis internas como `local`; constantes em CAIXA_ALTA
+- Padronizar logs com funções `info`, `warn`, `die`
+- Para cópias, usar `rsync -aHAX --relative` com exclusões definidas em array
+- Formatar comandos longos com arrays e quebras de linha para legibilidade
+- Evitar comentários inline desnecessários; escrever código autoexplicativo
+- Não imprimir segredos ou caminhos sensíveis nos logs

--- a/.cursor/rules/03-seguranca.mdc
+++ b/.cursor/rules/03-seguranca.mdc
@@ -1,0 +1,9 @@
+---
+alwaysApply: true
+---
+# Segurança e Privacidade
+
+- Nunca incluir tokens, senhas ou chaves privadas em código, logs ou commits
+- Excluir chaves privadas do backup: `${HOME}/.ssh/id_*` e `${HOME}/.ssh/*_key`
+- Validar o que entra no Git antes de commitar arquivos gerados
+- Preferir uso de variáveis de ambiente/Keychain no macOS para segredos

--- a/.cursor/rules/04-git-backup-policy.mdc
+++ b/.cursor/rules/04-git-backup-policy.mdc
@@ -1,0 +1,9 @@
+---
+alwaysApply: true
+---
+# Política de Git para Backups
+
+- O tarball gerado pelo [dotfiles_backup.sh](mdc:dotfiles_backup.sh) é adicionado ao Git quando `DO_GIT=1`
+- Mensagem de commit: `backup ${HOSTNAME} ${TIMESTAMP}`
+- O push é feito para o remoto `origin` no branch atual; é necessário que o repositório e o remoto existam
+- Em `DRY_RUN=1`, apenas logar as ações (não criar tarball nem fazer push)

--- a/.cursor/rules/05-ptbr-operacional.mdc
+++ b/.cursor/rules/05-ptbr-operacional.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+# Preferências Operacionais
+
+- Responder, documentar e nomear mensagens em PT-BR
+- Preferir caminhos absolutos em execuções/comandos e referências internas
+- Usar flags não interativas por padrão em automações (ex.: `--yes`, `--force` quando seguro)


### PR DESCRIPTION
- Adiciona regras do Cursor em .cursor/rules
- Cria script de backup com destino fixo e push automático do tarball
- Segurança: exclui chaves privadas e gera manifestos/inventário

Ao mergear, usar squash se preferir.