### PR TITLE
chore: backup automático (GitHub Actions/cron), backup manual e README

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,37 @@
+name: Dotfiles Backup
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # 05:00 UTC diariamente
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  backup:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configurar Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Executar backup (CI)
+        env:
+          PROJECT_DIR: ${{ github.workspace }}
+          DO_GIT: "1"
+          DRY_RUN: "0"
+          SKIP_HOME: "1"
+          SKIP_BREW: "1"
+          SKIP_VSCODE: "1"
+        run: |
+          chmod +x scripts/dotfiles_backup.sh || true
+          /bin/zsh scripts/dotfiles_backup.sh
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+## Dotfiles — Backup Automático e Manual (macOS)
+
+Este repositório contém automações para backup de dotfiles no macOS, com três formas de execução:
+
+- Manual: `scripts/backup_manual.sh`
+- Automático local (cron): `scripts/install_cron.sh`
+- Automático remoto (GitHub Actions): `.github/workflows/backup.yml`
+
+Cada execução gera um tarball no diretório do projeto com o padrão `dotfiles-${HOSTNAME}-${TIMESTAMP}.tar.gz` e faz commit/push automático (quando habilitado).
+
+### Itens incluídos
+
+- Arquivos comuns de shell e Git: `.zshrc`, `.zprofile`, `.gitconfig`, etc.
+- Diretórios de configuração como `.config/` e `.ssh/` (somente `config`, chaves privadas são excluídas)
+- Preferências do VS Code (settings, keybindings e snippets)
+- Outras preferências úteis (ex.: iTerm2)
+
+Listas completas em `backup/include.lst` e `backup/exclude.lst`.
+
+### Segurança e privacidade
+
+- Chaves privadas e materiais sensíveis são excluídos por padrão (`.ssh/id_*`, `.ssh/*_key`, `.gnupg/**` etc.)
+- Nunca armazene segredos em texto claro neste repositório
+
+### Scripts
+
+- `scripts/dotfiles_backup.sh`: script principal. Fluxo:
+  1. Copia itens do `$HOME` com `rsync` (listas de include/exclude)
+  2. Exporta `Brewfile` e extensões do VS Code (se disponíveis)
+  3. Gera inventário (`inventory.txt`) e manifesto (`manifest.sha256`)
+  4. Gera o tarball em `./`
+  5. (Opcional) Commit e push (`DO_GIT=1`)
+
+- `scripts/backup_manual.sh`: executa o backup com `DO_GIT=1` no diretório do projeto.
+
+- `scripts/install_cron.sh`: instala uma tarefa diária às 02:15 que executa o backup e registra logs em `logs/cron.log`.
+
+### GitHub Actions
+
+Workflow em `.github/workflows/backup.yml` roda diariamente às 05:00 UTC ou via disparo manual. No contexto de CI ele pula a coleta de `$HOME` e exportações de Brew/VS Code, mas ainda gera metadados e o tarball para registrar o estado e manter o repositório atualizado.
+
+### Variáveis de ambiente
+
+- `PROJECT_DIR`: diretório do projeto (padrão: `/Users/gabrielramos/dotfiles`)
+- `DO_GIT`: quando `1`, adiciona o tarball ao Git, faz commit e push
+- `DRY_RUN`: quando `1`, apenas simula
+- `SKIP_HOME`: quando `1`, não coleta itens do `$HOME`
+- `SKIP_BREW`: quando `1`, não exporta `Brewfile`
+- `SKIP_VSCODE`: quando `1`, não exporta extensões do VS Code
+
+### Uso rápido
+
+Manualmente:
+
+```bash
+/bin/zsh /Users/gabrielramos/dotfiles/scripts/backup_manual.sh
+```
+
+Instalar cron:
+
+```bash
+/bin/zsh /Users/gabrielramos/dotfiles/scripts/install_cron.sh
+```
+
+Executar direto o script principal (exemplo com dry-run):
+
+```bash
+DRY_RUN=1 DO_GIT=0 /bin/zsh /Users/gabrielramos/dotfiles/scripts/dotfiles_backup.sh
+```

--- a/backup/exclude.lst
+++ b/backup/exclude.lst
@@ -1,0 +1,27 @@
+# Lista de exclusão (rsync) relativa a $HOME
+
+# Segurança: chaves privadas e materiais sensíveis
+.ssh/id_*
+.ssh/*_key
+.ssh/*.pub
+.gnupg/**
+
+# Caches e temporários
+Library/Caches/**
+Library/Cache/**
+Library/Logs/**
+Library/Application Support/Code/Cache/**
+Library/Application Support/Code/CacheData/**
+Library/Application Support/Code/CachedData/**
+Library/Application Support/Google/**
+Library/Application Support/Slack/**
+.config/**/Cache/**
+.cache/**
+**/*.log
+**/*.tmp
+
+# Cloud/Volumes
+Library/CloudStorage/**
+Volumes/**
+
+

--- a/backup/include.lst
+++ b/backup/include.lst
@@ -1,0 +1,30 @@
+# Lista de inclusão (rsync) relativa a $HOME
+# Mantenha entradas específicas e diretórios com barra no final
+
+# Shell & Git
+.zshrc
+.zprofile
+.zshenv
+.bash_profile
+.bashrc
+.gitconfig
+.gitignore_global
+
+# Configurações gerais
+.editorconfig
+.aliases
+.exports
+
+# Diretórios de configuração
+.config/
+.ssh/
+
+# VS Code settings (macOS)
+Library/Application Support/Code/User/settings.json
+Library/Application Support/Code/User/keybindings.json
+Library/Application Support/Code/User/snippets/
+
+# iTerm2 (exemplo)
+Library/Preferences/com.googlecode.iterm2.plist
+
+

--- a/scripts/backup_manual.sh
+++ b/scripts/backup_manual.sh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+set -euo pipefail 2>/dev/null || true
+
+PROJECT_DIR="/Users/gabrielramos/dotfiles"
+
+export PROJECT_DIR
+export DO_GIT=1
+export DRY_RUN="${DRY_RUN:-0}"
+
+cd "${PROJECT_DIR}"
+"${PROJECT_DIR}/scripts/dotfiles_backup.sh"
+
+echo "Backup manual finalizado."
+
+

--- a/scripts/dotfiles_backup.sh
+++ b/scripts/dotfiles_backup.sh
@@ -1,0 +1,225 @@
+#!/bin/zsh
+
+set -euo pipefail 2>/dev/null || true
+set -euo
+setopt pipefail 2>/dev/null || true
+
+# ==============================================
+# dotfiles_backup.sh
+#
+# macOS (zsh) backup de dotfiles para o diretório do projeto.
+# Gera tarball nomeado: dotfiles-${HOSTNAME}-${TIMESTAMP}.tar.gz
+# Exporta Brewfile e extensões do VS Code, inventário e manifestos.
+# Opcionalmente faz commit/push no Git quando DO_GIT=1.
+# Respeita DRY_RUN=1 para apenas simular.
+# ==============================================
+
+# Preferir caminhos absolutos; permite override por variável de ambiente
+PROJECT_DIR="${PROJECT_DIR:-/Users/gabrielramos/dotfiles}"
+BACKUP_DIR="${PROJECT_DIR}"
+
+# Variáveis de controle
+DRY_RUN="${DRY_RUN:-0}"
+DO_GIT="${DO_GIT:-0}"
+
+# Descobrir caminhos de ferramentas de forma resiliente
+BREW_BIN="${BREW_BIN:-}"
+if [[ -z "${BREW_BIN}" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    BREW_BIN="$(command -v brew)"
+  elif [[ -x "/opt/homebrew/bin/brew" ]]; then
+    BREW_BIN="/opt/homebrew/bin/brew"
+  else
+    BREW_BIN=""
+  fi
+fi
+
+CODE_BIN="${CODE_BIN:-}"
+if [[ -z "${CODE_BIN}" ]]; then
+  if command -v code >/dev/null 2>&1; then
+    CODE_BIN="$(command -v code)"
+  elif [[ -x "/opt/homebrew/bin/code" ]]; then
+    CODE_BIN="/opt/homebrew/bin/code"
+  elif [[ -x "/usr/local/bin/code" ]]; then
+    CODE_BIN="/usr/local/bin/code"
+  else
+    CODE_BIN=""
+  fi
+fi
+
+HOSTNAME_SHORT="$(hostname -s || uname -n)"
+TIMESTAMP="$(/bin/date -u +%Y%m%dT%H%M%SZ)"
+TARBALL_NAME="dotfiles-${HOSTNAME_SHORT}-${TIMESTAMP}.tar.gz"
+TARBALL_PATH="${BACKUP_DIR}/${TARBALL_NAME}"
+
+INCLUDE_LIST="${PROJECT_DIR}/backup/include.lst"
+EXCLUDE_LIST="${PROJECT_DIR}/backup/exclude.lst"
+
+LOG() { printf "%s\n" "$*"; }
+
+abort() {
+  LOG "ERRO: $*" 1>&2
+  exit 1
+}
+
+ensure_prereqs() {
+  [[ -d "${PROJECT_DIR}" ]] || abort "Diretório do projeto não encontrado: ${PROJECT_DIR}"
+  if [[ "${SKIP_HOME:-0}" != "1" ]]; then
+    [[ -f "${INCLUDE_LIST}" ]] || abort "Lista de inclusão ausente: ${INCLUDE_LIST}"
+    [[ -f "${EXCLUDE_LIST}" ]] || abort "Lista de exclusão ausente: ${EXCLUDE_LIST}"
+  fi
+}
+
+make_staging() {
+  STAGING_DIR=$(mktemp -d /tmp/dotfiles_backup.XXXXXX)
+  INVENTORY_FILE="${STAGING_DIR}/inventory.txt"
+  MANIFEST_FILE="${STAGING_DIR}/manifest.sha256"
+  METADATA_DIR="${STAGING_DIR}/.backup_meta"
+  mkdir -p "${METADATA_DIR}"
+}
+
+collect_home_items() {
+  if [[ "${SKIP_HOME:-0}" == "1" ]]; then
+    LOG "SKIP_HOME=1 — pulando coleta de itens do HOME"
+    return 0
+  fi
+  LOG "Coletando itens do HOME (${HOME}) via rsync (listas: include/exclude)"
+  mkdir -p "${STAGING_DIR}/home"
+  # Executa rsync a partir do $HOME usando include/exclude para copiar apenas o necessário
+  pushd "${HOME}" >/dev/null
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    rsync -an --prune-empty-dirs \
+      --include-from "${INCLUDE_LIST}" \
+      --exclude-from "${EXCLUDE_LIST}" \
+      --exclude='*' ./ "${STAGING_DIR}/home/"
+  else
+    rsync -a --prune-empty-dirs \
+      --include-from "${INCLUDE_LIST}" \
+      --exclude-from "${EXCLUDE_LIST}" \
+      --exclude='*' ./ "${STAGING_DIR}/home/"
+  fi
+  popd >/dev/null
+}
+
+export_brewfile() {
+  if [[ "${SKIP_BREW:-0}" == "1" ]]; then
+    LOG "SKIP_BREW=1 — pulando export do Brewfile"
+    return 0
+  fi
+  if [[ -n "${BREW_BIN}" && -x "${BREW_BIN}" ]]; then
+    LOG "Exportando Brewfile"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      : # no-op em dry run
+    else
+      "${BREW_BIN}" bundle dump --force --file "${STAGING_DIR}/Brewfile" || LOG "Aviso: falha ao gerar Brewfile"
+      # Copia uma versão para o diretório do projeto para versionar
+      cp -f "${STAGING_DIR}/Brewfile" "${PROJECT_DIR}/Brewfile" 2>/dev/null || true
+    fi
+  else
+    LOG "Aviso: Homebrew não encontrado em ${BREW_BIN}; pulando Brewfile"
+  fi
+}
+
+export_vscode_extensions() {
+  if [[ "${SKIP_VSCODE:-0}" == "1" ]]; then
+    LOG "SKIP_VSCODE=1 — pulando export de extensões do VS Code"
+    return 0
+  fi
+  if [[ -n "${CODE_BIN}" && -x "${CODE_BIN}" ]]; then
+    LOG "Exportando extensões do VS Code"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      :
+    else
+      "${CODE_BIN}" --list-extensions > "${STAGING_DIR}/vscode-extensions.txt" || LOG "Aviso: falha ao listar extensões VS Code"
+      cp -f "${STAGING_DIR}/vscode-extensions.txt" "${PROJECT_DIR}/vscode-extensions.txt" 2>/dev/null || true
+    fi
+  else
+    LOG "Aviso: 'code' CLI do VS Code não encontrado; pulando export de extensões"
+  fi
+}
+
+write_metadata() {
+  LOG "Gerando inventário e manifestos"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    :
+  else
+    {
+      printf "host: %s\n" "${HOSTNAME_SHORT}"
+      printf "timestamp_utc: %s\n" "${TIMESTAMP}"
+      printf "script: dotfiles_backup.sh\n"
+    } > "${METADATA_DIR}/meta.yml"
+
+    (cd "${STAGING_DIR}" && env LC_ALL=C find . -type f -print0 | xargs -0 stat -f "%N|%z" | sort) > "${INVENTORY_FILE}" || true
+
+    # Manifesto SHA-256
+    if command -v shasum >/dev/null 2>&1; then
+      (cd "${STAGING_DIR}" && env LC_ALL=C find . -type f -print0 | xargs -0 shasum -a 256 | sort) > "${MANIFEST_FILE}" || true
+    elif command -v /sbin/shasum >/dev/null 2>&1; then
+      (cd "${STAGING_DIR}" && env LC_ALL=C find . -type f -print0 | xargs -0 /sbin/shasum -a 256 | sort) > "${MANIFEST_FILE}" || true
+    else
+      LOG "Aviso: shasum não encontrado; manifesto SHA-256 não gerado"
+    fi
+  fi
+}
+
+make_tarball() {
+  LOG "Empacotando em: ${TARBALL_PATH}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    LOG "DRY_RUN=1 — pulando criação do tarball"
+  else
+    mkdir -p "${BACKUP_DIR}"
+    # Empacota conteúdo do staging
+    (cd "${STAGING_DIR}" && tar -czf "${TARBALL_PATH}" .)
+  fi
+}
+
+git_commit_and_push() {
+  if [[ "${DO_GIT}" != "1" ]]; then
+    LOG "DO_GIT!=1 — não será feito commit/push"
+    return 0
+  fi
+  LOG "Fazendo commit e push para o repositório git"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    LOG "DRY_RUN=1 — pulando git add/commit/push"
+    return 0
+  fi
+  pushd "${PROJECT_DIR}" >/dev/null
+  if [[ -f "${TARBALL_PATH}" ]]; then
+    git add "${TARBALL_PATH}"
+  fi
+  if [[ -f "${PROJECT_DIR}/Brewfile" ]]; then
+    git add "${PROJECT_DIR}/Brewfile"
+  fi
+  # Não versionamos diretório staging; apenas tarball e artefatos persistentes (se houverem)
+  if ! git diff --cached --quiet; then
+    git commit -m "backup ${HOSTNAME_SHORT} ${TIMESTAMP}"
+    git push origin HEAD
+  else
+    LOG "Nada para commitar"
+  fi
+  popd >/dev/null
+}
+
+cleanup() {
+  if [[ -n "${STAGING_DIR:-}" && -d "${STAGING_DIR}" ]]; then
+    rm -rf "${STAGING_DIR}"
+  fi
+}
+
+main() {
+  LOG "Iniciando backup de dotfiles — host: ${HOSTNAME_SHORT}, ts: ${TIMESTAMP}"
+  ensure_prereqs
+  make_staging
+  trap cleanup EXIT
+  collect_home_items
+  export_brewfile
+  export_vscode_extensions
+  write_metadata
+  make_tarball
+  git_commit_and_push
+  LOG "Backup concluído"
+}
+
+main "$@"
+
+

--- a/scripts/install_cron.sh
+++ b/scripts/install_cron.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+set -euo pipefail 2>/dev/null || true
+
+PROJECT_DIR="/Users/gabrielramos/dotfiles"
+LOG_DIR="${PROJECT_DIR}/logs"
+mkdir -p "${LOG_DIR}"
+
+CRON_LINE="15 2 * * * SHELL=/bin/zsh PATH=/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin PROJECT_DIR=${PROJECT_DIR} DO_GIT=1 ${PROJECT_DIR}/scripts/dotfiles_backup.sh >> ${LOG_DIR}/cron.log 2>&1"
+
+TMP_CRON=$(mktemp)
+crontab -l 2>/dev/null | grep -v "dotfiles_backup.sh" > "${TMP_CRON}" || true
+echo "${CRON_LINE}" >> "${TMP_CRON}"
+crontab "${TMP_CRON}"
+rm -f "${TMP_CRON}"
+
+echo "Cron instalado. Próxima execução diária às 02:15. Logs em ${LOG_DIR}/cron.log"
+
+


### PR DESCRIPTION
Este PR adiciona automações de backup de dotfiles.

Principais mudanças:
- Backup automático via GitHub Actions com agendamento diário (05:00 UTC) e disparo manual
- Backup automático local via cron (diário às 02:15, com logs)
- Backup manual via script dedicado
- Listas de include/exclude para rsync, respeitando segurança (exclusão de chaves privadas e caches)
- Exportação opcional de Brewfile e extensões do VS Code
- Geração de inventário e manifesto SHA-256
- README com instruções de uso

Como testar:
- Manual: /bin/zsh /Users/gabrielramos/dotfiles/scripts/backup_manual.sh
- Cron: /bin/zsh /Users/gabrielramos/dotfiles/scripts/install_cron.sh (verificar logs em logs/cron.log)
- CI: Disparar workflow "Dotfiles Backup" manualmente

Observações:
- Em CI, a coleta de $HOME e exportações de Brew/VS Code são puladas (SKIP_*=1)
- Tarball gerado: dotfiles-${HOSTNAME}-${TIMESTAMP}.tar.gz
- Commit/push automáticos quando DO_GIT=1